### PR TITLE
Cas43/update for winter 21

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ In this lab you will create a strategy pattern for sorting a collection of expre
 
 ## Container Classes
 
-You will start this lab by creating two expression tree containers: one that uses a vector to hold your trees (class `VectorContainer`) and one that uses a standard list (class `ListContainer`). Each of these container classes should be able to hold any amount of different expressions each of which can be of any size. You will implement them both as subclasses of the following `Container` abstract base class, which has been provided to you in container.h. You should create each one independently, creating tests for them using the google test framework before moving on. Each container should be it’s own commit with a proper commit message. Optionally you can create each one as a branch and merge it in once it has been completed.
+You will start this lab by creating two expression tree containers: one that uses a vector to hold your trees (class `VectorContainer`) and one that uses a standard list (class `ListContainer`). Each of these container classes should be able to hold any number of different expressions, each of which can be of any size. You will implement them both as subclasses of the following `Container` abstract base class, which has been provided to you in container.hpp. You should create each one independently, creating tests for them using the google test framework before moving on. Each container should be it’s own commit with a proper commit message. Optionally you can create each one as a branch and merge it in once it has been completed.
 
 ```c++
 class Container {
@@ -57,7 +57,7 @@ class Sort {
 };
 ```
 
-**Note:** your container class requires a reference to your sorting class and vice-versa, a situation known as a circular dependency. Due to the way the C++ compiler works, resolving circular dependencies will require you to use [forward declarations](http://www.umich.edu/~eecs381/handouts/IncompleteDeclarations.pdf) and compile your classes as object files by seperating the class declarations (header) from the class definitions (source) and adding the source files to your CMakeLists.txt. 
+**Note:** your container class requires a pointer to your sorting class and vice-versa, a situation known as a circular dependency. Due to the way the C++ compiler works, resolving circular dependencies will require you to use [forward declarations](http://www.umich.edu/~eecs381/handouts/IncompleteDeclarations.pdf).
 
 You must test all the combinations of containers and sorting objects together using googletest. The following code serves as a basic test for using the SelectionSort class to sort a VectorContainer, but you should create a full test suite for each class and the appropriate class combinations.
 
@@ -94,7 +94,7 @@ TEST(SortTestSet, SelectionSortTest) {
     Add* TreeB = new Add(three, two);
 
     Op* ten = new Op(10);
-    Ope* six = new Op(6);
+    Op* six = new Op(6);
     Sub* TreeC = new Sub(ten, six);
 
     VectorContainer* container = new VectorContainer();

--- a/base.hpp
+++ b/base.hpp
@@ -7,6 +7,7 @@ class Base {
     public:
         /* Constructors */
         Base() { };
+        virtual ~Base() {}
 
         /* Pure Virtual Functions */
         virtual double evaluate() = 0;

--- a/container.hpp
+++ b/container.hpp
@@ -17,15 +17,15 @@ class Container {
         Container(Sort* function) : sort_function(function) { };
 
         /* Non Virtual Functions */
-        void set_sort_function(Sort* sort_function); // set the type of sorting algorithm
+        void set_sort_function(Sort* sort_function_); // set the type of sorting algorithm
+        // calls on the previously set sorting-algorithm. Checks if sort_function is not null, throw exception if otherwise
+        void sort();
 
         /* Pure Virtual Functions */
         // push the top pointer of the tree into container
         virtual void add_element(Base* element) = 0;
         // iterate through trees and output the expressions (use stringify())
         virtual void print() = 0;
-        // calls on the previously set sorting-algorithm. Checks if sort_function is not null, throw exception if otherwise
-        virtual void sort() = 0;
 
         /* Essentially the only functions needed to sort */
         //switch tree locations

--- a/container.hpp
+++ b/container.hpp
@@ -15,6 +15,7 @@ class Container {
         /* Constructors */
         Container() : sort_function(nullptr) { };
         Container(Sort* function) : sort_function(function) { };
+        virtual ~Container() {}
 
         /* Non Virtual Functions */
         void set_sort_function(Sort* sort_function_); // set the type of sorting algorithm

--- a/sort.hpp
+++ b/sort.hpp
@@ -1,8 +1,6 @@
 #ifndef __SORT_HPP__
 #define __SORT_HPP__
 
-#include "container.hpp"
-
 class Container;
 
 class Sort {

--- a/sort.hpp
+++ b/sort.hpp
@@ -6,7 +6,7 @@ class Container;
 class Sort {
     public:
         /* Constructors */
-        Sort();
+        virtual ~Sort() {}
 
         /* Pure Virtual Functions */
         virtual void sort(Container* container) = 0;


### PR DESCRIPTION
The comments about needing to put definitions in cpp files to avoid circular dependencies are incorrect.  I did not do this, and I did not run into problems.  The definition of Sort does not need anything more than a forward declaration of Container.  Remove the include loop (never do that), and this one is fine header-only.

I don't see any reason for the sort routine to be virtual.
